### PR TITLE
Change glob pattern to find libusb dll for x64

### DIFF
--- a/src/pyhid_usb_relay/find.py
+++ b/src/pyhid_usb_relay/find.py
@@ -24,7 +24,7 @@ def _get_backend():
 
     # Manually find the libusb DLL and create a backend using it. I don't know
     # why Python can't find this on its own
-    libpath = next(pathlib.Path(libusb.__file__).parent.rglob("x64/libusb-1.0.dll"))
+    libpath = next(pathlib.Path(libusb.__file__).parent.rglob("x*64/libusb-1.0.dll"))
     return usb.backend.libusb1.get_backend(find_library=lambda x: str(libpath))
 
 


### PR DESCRIPTION
Just a minor change to make the glob pattern compatible with previous and latest versions of libusb. In recent versions ([>= 1.0.29.post6](https://github.com/karpierz/libusb/tree/1.0.29.post6/src/libusb/_platform/windows)) the folder containing the dll was renamed from 'x64' to 'x86_64'.